### PR TITLE
Ensuring callback provided to Shapefile constructor is executed even if a dbf file is not provided

### DIFF
--- a/shapefile.js
+++ b/shapefile.js
@@ -85,7 +85,7 @@
                 that.addDBFDataToGeoJSON(data)
                 that._postMessage()
             })
-        else this._postMessage
+        else this._postMessage()
     }
 
     Shapefile.prototype = {


### PR DESCRIPTION
I have a use case where I don't really care about the attributes provided in a dbf file. This pull request makes sure _postMessage and thus the constructor callback is called even if no DBF file is indicated in the options.
