### PR TITLE
Fixed support for Point datasets

### DIFF
--- a/shapefile.js
+++ b/shapefile.js
@@ -256,20 +256,22 @@
             for (var r = 0, record; record = records[r]; r++){
                 feature = {}, fbounds = record.bounds, points = record.points, parts = record.parts
                 feature.type = "Feature"
-                feature.bbox = [
-                    fbounds.left,
-                    fbounds.bottom,
-                    fbounds.right,
-                    fbounds.top
-                ]
+                if (record.shapeType !== 'Point') {
+                    feature.bbox = [
+                        fbounds.left,
+                        fbounds.bottom,
+                        fbounds.right,
+                        fbounds.top
+                    ]                    
+                }
                 geometry = feature.geometry = {}
 
                 switch (record.shapeType) {
                     case "Point":
                         geometry.type = "Point"
                         geometry.coordinates = [
-                            record.points.x,
-                            record.points,y ]
+                            record.x,
+                            record.y ]
                         break
                     case "MultiPoint":
                     case "PolyLine":


### PR DESCRIPTION
While some support existed, an attempt was being
made to create an unnecessary(?) bounding box for
each point feature. Also swapped access of the x,y
coordinates from record.geometry.x|y to record.x|y.
