### PR TITLE
Update to file handling for Safari compatibility

### DIFF
--- a/dbf.js
+++ b/dbf.js
@@ -56,7 +56,7 @@
         }
 
     var DBF = function(url, callback){
-        if (!!url.lastModifiedDate)
+        if (!!(url.lastModifiedDate || url.lastModified))
             this.handleFile(url, callback);
         else
             this.handleUri(url, callback);

--- a/shapefile.js
+++ b/shapefile.js
@@ -69,7 +69,7 @@
         var o = typeof o == "string" ? {shp: o} : o
         this.callback = callback
 
-        if (!!o.shp.lastModifiedDate)
+        if (!!(o.shp.lastModifiedDate || o.shp.lastModified))
             this.handleFile(o);
         else
             this.handleUri(o);


### PR DESCRIPTION
Safari has `lastModified`, not `lastModifiedDate`, on the file objects